### PR TITLE
Key info components in action bar should always have 20px margins when in default mode

### DIFF
--- a/src/app/public/modules/summary-action-bar/summary-action-bar.component.scss
+++ b/src/app/public/modules/summary-action-bar/summary-action-bar.component.scss
@@ -46,6 +46,10 @@
   flex-wrap: wrap;
   flex-grow: 1;
 	margin-right: $sky-margin;
+
+  ::ng-deep sky-key-info {
+    margin: 0 $sky-margin-double 0 0;
+  }
 }
 
 .sky-summary-action-bar-details-expand {


### PR DESCRIPTION
Our demos showed CSS adding this `20px` margin, but we can do this automatically for the consumer. Since we're doing this for them in modern theme, we should probably do the same in default.